### PR TITLE
Fix bug with unescaped \x in --asciicmd help documentation.

### DIFF
--- a/shellcode2exe.py
+++ b/shellcode2exe.py
@@ -171,7 +171,7 @@ def main(argv):
     parser.add_option("-o", "--os", metavar="OS",
                       help="target operating system [default: windows]")
     parser.add_option("-c", "--asciicmd", action="store_true", dest="asciicmd",
-                      help="enable ascii entry in command line (e.g. -c '\x90\x90')")
+                      help="enable ascii entry in command line (e.g. -c '\\x90\\x90')")
     parser.add_option("-s", "--asciifile", action="store_true", dest="asciifile",
                       help="enable ascii entry in input file")
     parser.add_option("-d", "--unicodecmd", action="store_true", dest="unicodecmd",


### PR DESCRIPTION
Sorry, there was an issue with unescaped \x in the asciicmd help documentation.
